### PR TITLE
Use yaml.safe_load(...) and add dateparser to deps

### DIFF
--- a/dirt/libs/incident.py
+++ b/dirt/libs/incident.py
@@ -209,7 +209,7 @@ class Incident(object):
             return
 
         with open(self.metafile) as f:
-            metadata = yaml.load(stream=f)
+            metadata = yaml.safe_load(stream=f)
         self.cname = metadata.get("cname")
         self.closed = metadata.get("closed", False)
         self.owner = metadata.get("owner", "<unknown>")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 click
 colorama
 PyYAML
+dateparser


### PR DESCRIPTION
Hi Paweł, 

this PR fixes two small issues:
- Add the package `dateparser` to `requirements`, because it is needed but will not be installed automatically 
- Use `yaml.safe_load(...)` instead of `yaml.load(...)` in `dirt/libs/incident.py` to avoid a ugly warning with PyYaml 5.17

Thanks for providing dirt!!! I just started tinkering with it. 
Better zsh-support would be great. Maybe I can get my head around that. :)

Best regards
Jan 